### PR TITLE
chore: remove list_spells method and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Synchronous Metadata Generation**: Metadata is now synced during the standard `Grimorium._sync_initialize()` path, ensuring consistency with async usage.
 - **ADK Alignment**: Standardized `Grimorium` and `SpellSync` with Google ADK `BaseToolset` protocols, including async `close()` lifecycles and `from_config` stubs.
 
+### Removed
+- **Spells Listing**: Removed the `list_spells` method to simplify the toolset and align with the hierarchical discovery loop.
+
 ### Changed
 - **Consolidated Configuration**: Moved all coverage settings from `.coveragerc` into `pyproject.toml` for a cleaner project root.
 - **Improved Test Suite**: Resolved all `PytestWarning` entries and cleaned up lint warnings in tests.

--- a/README.md
+++ b/README.md
@@ -106,12 +106,11 @@ root_agent = LlmAgent(
 
 ### Agent Discovery Flow
 
-A Magetools Grimorium exposes 4 tools to your agent:
+A Magetools Grimorium exposes 3 tools to your agent:
 
 1. `discover_grimoriums(query)` – Search for a grimorium using a query
 2. `discover_spells(grimorium_id, query)` – Search for a spell within a grimorium
 3. `execute_spell(spell_name, arguments)` – Run a spell
-4. `list_spells()` – List the names of all available spells from all linked grimoriums(may remove this soon...)
 
 **Example:**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,7 +27,6 @@ The Magetools CLI has received several usability upgrades:
 - **Windows Robustness**: Fixed encoding issues and removed problematic emojis to ensure a smooth experience on Windows terminals.
 
 ## 🛠️ Highlights from v1.1.0
-- **Secure Spell Listing**: The new `list_spells` method allows agents to see available tools while respecting your `allowed_collections` security boundaries.
 - **Enhanced Type Hinting**: Improved codebase robustness with comprehensive modern type hints.
 
 ## 📦 Getting Started with v1.2.0

--- a/example/.magetools/example_grim/tools1.py
+++ b/example/.magetools/example_grim/tools1.py
@@ -4,6 +4,7 @@ from magetools import spell
 
 from ..example_book.tools2 import user_name
 
+
 @spell
 async def get_user_location() -> Dict[str, Any]:
     """Gets the user's current city and country.


### PR DESCRIPTION
This PR removes the `list_spells` method from the `Grimorium` toolset and cleans up all associated documentation and tests.

### Changes:
- Removed `list_spells` implementation from `src/magetools/grimorium.py`.
- Removed `list_spells` tool registration.
- Updated unit tests in `tests/test_grimorium.py`.
- Cleaned up documentation in `README.md`, `RELEASE_NOTES.md`, and `CHANGELOG.md`.

This aligns the toolset with the hierarchical discovery loop (grimoriums -> spells -> execution) and simplifies the API.