### PR TITLE
chore: bump version to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - 2026-02-10
+## [1.3.0] - 2026-02-16
 
 ### Added
 - **100% Test Coverage**: Achieved full line and branch coverage for the `SpellSync` module and core codebase.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
-# Release Notes - Magetools v1.2.0
+# Release Notes - Magetools v1.3.0
 
-We are excited to announce the **v1.2.0** release of **Magetools**! This version represents a major milestone in security, performance, and developer accessibility, making Magetools the most robust solution for hierarchical agentic tool discovery.
+We are excited to announce the **v1.3.0** release of **Magetools**! This version represents a major milestone in security, performance, and developer accessibility, making Magetools the most robust solution for hierarchical agentic tool discovery.
 
-## 🌟 What's New in v1.2.0
+## 🌟 What's New in v1.3.0
 
 ### 🧠 Automatic Metadata Synchronization
 Magetools now automatically generates `grimorium_summary.md` files for your tool collections. These high-density technical summaries are powered by Google Gemini and provide agents with the critical context needed to choose the right tools without reading every line of code.
@@ -29,7 +29,7 @@ The Magetools CLI has received several usability upgrades:
 ## 🛠️ Highlights from v1.1.0
 - **Enhanced Type Hinting**: Improved codebase robustness with comprehensive modern type hints.
 
-## 📦 Getting Started with v1.2.0
+## 📦 Getting Started with v1.3.0
 Upgrade your project and rebuild your tool metadata:
 ```bash
 # Update to latest version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magetools"
-version = "1.2.0"
+version = "1.3.0"
 description = "Dynamic tool discovery for AI agents using the MCP-Zero Active Discovery pattern"
 readme = "README.md"
 authors = [

--- a/src/magetools/__init__.py
+++ b/src/magetools/__init__.py
@@ -7,7 +7,7 @@ from .spellsync import SpellSync
 # Alias for nicer decorator usage
 spell = register_spell
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 __all__ = [
     "Grimorium",
     "SpellSync",

--- a/uv.lock
+++ b/uv.lock
@@ -1534,7 +1534,7 @@ wheels = [
 
 [[package]]
 name = "magetools"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Bumping version to v1.3.0 due to v1.2.0 already existing on PyPI. Includes all recent changes and list_spells removal.